### PR TITLE
Add command to install current version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,6 @@ release:
 	-mkdir -p $(BUILD_DIR)
 	GOOS=$(GOOS) GOARCH=$(GOARCH) GO111MODULE=on CGO_ENABLED=0 go build -o $(BUILD_DIR)/$(NAME)$(ext) ./app/main.go
 	cd release ; $(archiveCmd)
+
+install: all
+	cp release/$(NAME) $(GOPATH)/bin/


### PR DESCRIPTION
After making a fresh build it could be very convenient to install the updated app in the system to test with existing blogs.

This adds `make install` command that builds and installs the app from sources.