### PR TITLE
Add watch mode and dev server

### DIFF
--- a/app/internal/cli.go
+++ b/app/internal/cli.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Opts struct {
-	Version bool
-	Path    string
+	Version   bool
+	WatchMode bool
+	Path      string
 }
 
 // GetCLIOptions parse CLI args and make Opts
@@ -16,9 +17,13 @@ func GetCLIOptions() Opts {
 	//    https://github.com/freetonik/underblog/issues/10
 
 	version := flag.Bool("version", false, "prints current version")
+	watchMode := flag.Bool("watch", false, "launchs in watch mode")
+
 	flag.Parse()
+
 	return Opts{
-		Version: *version,
-		Path:    "",
+		Version:   *version,
+		WatchMode: *watchMode,
+		Path:      "",
 	}
 }

--- a/app/internal/cli.go
+++ b/app/internal/cli.go
@@ -17,7 +17,7 @@ func GetCLIOptions() Opts {
 	//    https://github.com/freetonik/underblog/issues/10
 
 	version := flag.Bool("version", false, "prints current version")
-	watchMode := flag.Bool("watch", false, "launchs in watch mode")
+	watchMode := flag.Bool("watch", false, "launches in watch mode")
 
 	flag.Parse()
 

--- a/app/internal/watch_mode.go
+++ b/app/internal/watch_mode.go
@@ -1,0 +1,58 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/radovskyb/watcher"
+	"log"
+	"net/http"
+	"time"
+)
+
+func WatchForChangedFiles(rebuildBlog func()) {
+	w := watcher.New()
+
+	go func() {
+		for {
+			select {
+			case <-w.Event:
+				rebuildBlog()
+			case err := <-w.Error:
+				log.Fatalln(err)
+			case <-w.Closed:
+				return
+			}
+		}
+	}()
+
+	// Watch these files for changes.
+	files := []string{"./index.html", "post.html"}
+	for _, file := range files {
+		if err := w.Add(file); err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	directories := []string{"./markdown", "./css"}
+	for _, directory := range directories {
+		if err := w.AddRecursive(directory); err != nil {
+			log.Fatalln(err)
+		}
+	}
+
+	if err := w.Start(time.Millisecond * 200); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func RunDevelopmentWebserver() {
+	// todo: extract ./public to constant
+	http.Handle("/", http.FileServer(http.Dir("./public")))
+	// todo: check if port is not occupied
+	// todo: change port via cli argument
+	port := 8080
+	fmt.Printf("Development webserver is available at http://%s:%v/\n", "localhost", port)
+	addr := fmt.Sprintf(":%v", port)
+	if err := http.ListenAndServe(addr, nil); err != nil {
+		panic(err)
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -24,14 +24,11 @@ func main() {
 	if opts.WatchMode {
 		fmt.Println("Starting in watch mode...")
 		go makeBlog(opts)
+		go internal.WatchForChangedFiles(func() { makeBlog(opts) })
+		internal.RunDevelopmentWebserver()
 	} else {
 		fmt.Println("Starting...")
 		makeBlog(opts)
-	}
-
-	if opts.WatchMode {
-		go internal.WatchForChangedFiles(func() { makeBlog(opts) })
-		internal.RunDevelopmentWebserver()
 	}
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -21,19 +21,26 @@ func main() {
 		os.Exit(0)
 	}
 
-	start := time.Now()
-
 	if opts.WatchMode {
-		fmt.Println("Starting Underblog in watch mode...")
+		fmt.Println("Starting in watch mode...")
+		go makeBlog(opts)
 	} else {
 		fmt.Println("Starting...")
+		makeBlog(opts)
 	}
 
+	if opts.WatchMode {
+		go internal.WatchForChangedFiles(func() { makeBlog(opts) })
+		internal.RunDevelopmentWebserver()
+	}
+}
+
+func makeBlog(opts internal.Opts) {
+	start := time.Now()
 	err := cmd.MakeBlog(opts)
 	if err != nil {
 		log.Fatalf("Can't make a blog: %v", err)
 	}
-
 	elapsed := time.Since(start)
 	log.Printf("Done in %s", elapsed)
 }

--- a/app/main.go
+++ b/app/main.go
@@ -15,6 +15,7 @@ func main() {
 	fmt.Printf("Underblog %s\n", revision)
 
 	opts := internal.GetCLIOptions()
+
 	if opts.Version {
 		fmt.Printf("Current ver.: %s\n", revision)
 		os.Exit(0)
@@ -22,7 +23,12 @@ func main() {
 
 	start := time.Now()
 
-	fmt.Printf("Starting...\n")
+	if opts.WatchMode {
+		fmt.Println("Starting Underblog in watch mode...")
+	} else {
+		fmt.Println("Starting...")
+	}
+
 	err := cmd.MakeBlog(opts)
 	if err != nil {
 		log.Fatalf("Can't make a blog: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/freetonik/underblog
 go 1.13
 
 require (
+	github.com/radovskyb/watcher v1.0.7
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	gopkg.in/russross/blackfriday.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/radovskyb/watcher v1.0.7 h1:AYePLih6dpmS32vlHfhCeli8127LzkIgwJGcwwe8tUE=
+github.com/radovskyb/watcher v1.0.7/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 gopkg.in/russross/blackfriday.v2 v2.0.0 h1:+FlnIV8DSQnT7NZ43hcVKcdJdzZoeCmJj4Ql8gq5keA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# github.com/radovskyb/watcher v1.0.7
+github.com/radovskyb/watcher
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # gopkg.in/russross/blackfriday.v2 v2.0.0


### PR DESCRIPTION
First naive implementation of the watch mode and dev server. 

With `-watch` flag it starts monitoring changes in `./css` and `./markdown` directories, and in template files. When file change is found it rebuild the whole blog. 

Blog is available at http://localhost:8080/ while the app is in the watch mode.

It's prototype-ish and RFC, so no tests at the moment :-)

Later / some day:
- inject js to automatically reload page 
- rebuild only changed files
- rebuild index only when dates, slugs or post titles are changed